### PR TITLE
Series of little suggestions from latest sessions

### DIFF
--- a/DataSafe/lab100/content.md
+++ b/DataSafe/lab100/content.md
@@ -53,7 +53,7 @@ Enter all required details:
 * CPU Core Count :	1
 * Storage (TB) : 1
 * Auto scaling : **Leave Unchecked**
-* Password :	**OraclePTS#2020**
+* Password :	**OraCumulus#2020**
 * Network access : Leave default selection
 * License Type : BYOL (My Organization Already owns Oracle Database…)
 
@@ -160,6 +160,28 @@ Use SQL Developer to view HCM data. We will anonymize this data in Lab 5.
 
 
 ![Page](./images/img14.png " ")
+
+Continue with **Lab 2**.
+
+## STEP 8: Fix the database time zone if necessary
+
+An ATP-S instance is provisioned as a PDB which inherits its time zone from the OCI region. If you are in the same time zone as your OCI Data Center (region), you do not have to do anything.
+
+However, if you are in a different region, it is recommended to update the ATP time zone to reflect your own. For example, if you work from Tokyo but have provisioned an ATP-S instance in the US, execute the following to update the time zone.
+
+````
+<copy>
+ALTER DATABASE SET TIME_ZONE ='Asia/Tokyo';
+</copy>
+````
+
+Now restart the database from the OCI Console and check the new time zone by executing:
+
+````
+<copy>
+SELECT DBTIMEZONE FROM DUAL;
+</copy>
+````
 
 Continue with **Lab 2**.
 

--- a/DataSafe/lab200/content.md
+++ b/DataSafe/lab200/content.md
@@ -44,13 +44,6 @@ Data Safe uses a pre-created ATP user (DS$ADMIN) that is enabled when the instan
 The features that you can use depend on the roles granted to the Oracle Data Safe service account on that target database.
 Note that some basic roles are granted by default, allowing ADMIN to run simple security and user assessments.
 
-Change the TimeZome accordingly
-
-`` 
-ALTER DATABASE SET TIME_ZONE ='Asia/Tokyo'
-`` 
-
-and restart the database from the OCI Console
 
 To enable all other Data Safe features, connect to ATP-S with SQL Developer as user **ADMIN** and execute the following GRANTs:
 

--- a/lab000/lab000_accessing.md
+++ b/lab000/lab000_accessing.md
@@ -73,10 +73,13 @@ To connect to the dbclient or secdb servers from command line, use the following
 
     $ cd /<path-to-keys-folder>/
 
-Use the actual IP address for each server, to open 2 terminals:
+Use the actual IP address for each server to create each terminal session:
 
     $ ssh -i dbseckey oracle@ip.address
 
+The syntax to create an SSH tunnel to secdb enabling a VNC connection should be:
+
+  ssh -L 5902:localhost:5902 -i .ssh/dbseckey oracle@ip.address
 
 ## Step 2: Create a GUI connection to secdb's desktop
 

--- a/lab500/lab500_privilege_analysis.md
+++ b/lab500/lab500_privilege_analysis.md
@@ -18,14 +18,14 @@ In our example, we will reduce the privileges granted to **DBA\_NICOLE** to the 
 
 ## Step 1 : Check DBA\_NICOLE's current role ##
 
-**DBA\_NICOLE** is a junior DBA who was initially granted the full **DBA** role. Run the following script from a terminal window to the secdb server.
+**DBA\_NICOLE** is a junior DBA who was initially granted the full **DBA** role. Run the following script from a terminal window to the **secdb** server.
 
 ````
-$ <copy>cd /home/oracle/HOL/lab05_pa</copy>
+[oracle@secdb ~]$ <copy>cd /home/oracle/HOL/lab05_pa</copy>
 ````
 
 ````
-$ <copy>pa10_show_nicole_privs.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa10_show_nicole_privs.sh</copy>
 
 (...)
 SQL> --
@@ -44,7 +44,7 @@ DBA_NICOLE           DBA
 **DBA\_DEBRA** is the main **DBA**. Before beginning, let us make sure she has the **CAPTURE\_ADMIN** role required to execute a privilege analysis.
 
 ````
-$ <copy>pa11_show_debra_privs.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa11_show_debra_privs.sh</copy>
 
 (...)
 SQL> --
@@ -64,7 +64,7 @@ TRUE
 We can now create a privilege analysis job to capture the privileges used by **DBA\_NICOLE**.
 
 ````
-$ <copy>pa20_create_capture.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa20_create_capture.sh</copy>
 
 (...)
 SQL> --
@@ -94,7 +94,7 @@ NICOLE_PRIVS_ANALYSIS     CONTEXT         N
 **DBA\_DEBRA** can now start the capture process.
 
 ````
-$ <copy>pa21_start_capture.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa21_start_capture.sh</copy>
 
 (...)
 SQL> --
@@ -115,7 +115,7 @@ PL/SQL procedure successfully completed.
 Now that the capture process is running, **Nicole** can connect and do her task. For instance, she may work as some SQL tuning tasks.
 
 ````
-$ <copy>pa30_work_nicole.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa30_work_nicole.sh</copy>
 
 (...)
 SQL> --
@@ -139,7 +139,7 @@ Explained.
 When **Debra** is sure **Nicole** has executed a representative subset of her tasks, she can stop the capture process.
 
 ````
-$ <copy>pa40_stop_capture.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa40_stop_capture.sh</copy>
 
 (...)
 SQL> --
@@ -178,7 +178,7 @@ NICOLE_PRIVS_ANALYSIS     CONTEXT         N
 
 
 ````
-$ <copy>pa50_generate_result.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa50_generate_result.sh</copy>
 
 (...)
 SQL>
@@ -205,7 +205,7 @@ We can then revoke **DBA** from **NICOLE** and replace it by this **DBA\_TUNING\
 
 
 ````
-$ <copy>pa60_show_used_privs.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa60_show_used_privs.sh</copy>
 
 (...)
 SQL> -- Show privileges required by Nicole
@@ -259,7 +259,7 @@ GRANT READ ON SYSTEM.PRODUCT_PRIVS to dba_tuning_role;
 Rn the following script to create and grant an ad hoc role to NICOLE
 
 ````
-$ <copy>pa70_set_new_role.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa70_set_new_role.sh</copy>
 
 (...)
 SQL> -- Create and grant an ad hoc role to NICOLE
@@ -309,7 +309,7 @@ Grant succeeded.
 Finally, we can run verify that Nicole is still able to complete her tasks
 
 ````
-$ <copy>pa30_work_nicole.sh</copy>
+[oracle@secdb lab05_pa]$ <copy>pa30_work_nicole.sh</copy>
 
 (...)
 SQL> --

--- a/lab600/lab600_database_vault.md
+++ b/lab600/lab600_database_vault.md
@@ -470,7 +470,7 @@ ORA-00942: table or view does not exist
 (...)
 ````
 
-## Step 4 : Using Database Vault to enforce a trusted appliaction path  ##
+## Step 4 : Using Database Vault to enforce a trusted application path  ##
 
 In Oracle Database Vault, you can create a **Secure Application Role** that you enable with an Oracle Database Vault rule set.
 
@@ -490,7 +490,7 @@ Here is the outline of the configuration :
 
 ### Step 4a : Create the rules ###
 
-We will create three rules.
+Execute the following commands from **secdb** to create three rules.
 
 ````
 [oracle@secdb ~]$ <copy>cd /home/oracle/HOL/lab06_dbv/d_secapprole</copy>
@@ -506,7 +506,7 @@ SQL>  */
 SQL> begin
   2    DBMS_MACADM.CREATE_RULE(
   3      rule_name   => 'Check host',
-  4      rule_expr   => 'rtrim(SYS_CONTEXT(''USERENV'',''HOST''),''.localdomain'')=''olclient'''
+  4      rule_expr   => 'rtrim(SYS_CONTEXT(''USERENV'',''HOST''),''.localdomain'')=''dbclient'''
   5      );
   6  end;
   7  /

--- a/lab600/lab600_database_vault.md
+++ b/lab600/lab600_database_vault.md
@@ -28,11 +28,11 @@ We first create (as **SYS**) the common users which will become the **Database V
 Run the following script from a terminal window to the secdb server.
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv/a_setup</copy>
+[oracle@secdb ~]$ <copy>cd /home/oracle/HOL/lab06_dbv/a_setup</copy>
 ````
 
 ````
-$ <copy>dbvsetup10_config.sh</copy>
+[oracle@secdb a_setup]$ <copy>dbvsetup10_config.sh</copy>
 
 (...)
 SQL> --
@@ -58,7 +58,7 @@ PL/SQL procedure successfully completed.
 We now need to **enable** Database Vault in the CDB.
 
 ````
-$ <copy>dbvsetup11_enable.sh</copy>
+[oracle@secdb a_setup]$ <copy>dbvsetup11_enable.sh</copy>
 
 (...)
 SQL> begin
@@ -72,7 +72,7 @@ PL/SQL procedure successfully completed.
 Finally we need to **restart** the instance.
 
 ````
-$ <copy>dbvsetup12_restart.sh</copy>
+[oracle@secdb a_setup]$ <copy>dbvsetup12_restart.sh</copy>
 
 (...)
 SQL> shutdown immediate
@@ -101,7 +101,7 @@ We need to run similar scripts for the pluggable database **PDB1**.
 Create common users to become the **Database Vault Owner** and the **Database Account Manager**.
 
 ````
-$ <copy>dbvsetup20_configPDB1.sh</copy>
+[oracle@secdb a_setup]$ <copy>dbvsetup20_configPDB1.sh</copy>
 
 (...)
 SQL> alter session set container=pdb1;
@@ -132,7 +132,7 @@ PL/SQL procedure successfully completed.
 **Enable** Database Vault in PDB1.
 
 ````
-$ <copy>dbvsetup21_enablePDB1.sh</copy>
+[oracle@secdb a_setup]$ <copy>dbvsetup21_enablePDB1.sh</copy>
 
 (...)
 SQL> begin
@@ -146,7 +146,7 @@ PL/SQL procedure successfully completed.
 **Restart** PDB1.
 
 ````
-$ <copy>dbvsetup22_restartPDB1.sh</copy>
+[oracle@secdb a_setup]$ <copy>dbvsetup22_restartPDB1.sh</copy>
 
 (...)
 SQL> alter session set container=pdb1;
@@ -182,11 +182,11 @@ Database operations control does not block PDB database administrators. To block
 Run the following script to enable Ops Control in the CDB.
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv/b_ops_control</copy>
+[oracle@secdb ]$ <copy>cd /home/oracle/HOL/lab06_dbv/b_ops_control</copy>
 ````
 
 ````
-$ <copy>opsctl_10_enable.sh</copy>
+[oracle@secdb b_ops_control]$ <copy>opsctl_10_enable.sh</copy>
 
 (...)
 SQL*Plus: Release 19.0.0.0.0 - Production on Tue May 12 14:33:47 2020
@@ -203,7 +203,7 @@ PL/SQL procedure successfully completed.
 Verify the status (**DV\_APP\_PROTECTION** is **ENABLED**).
 
 ````
-$ <copy>opsctl_20_status.sh</copy>
+[oracle@secdb b_ops_control]$ <copy>opsctl_20_status.sh</copy>
 
 (...)
 SQL> select * from dba_dv_status;
@@ -220,7 +220,7 @@ DV_ENABLE_STATUS     TRUE
 Let us now verify that **SYS** or **SYSTEM** cannot access local data in **PDB1**.
 
 ````
-$ <copy>opsctl_30_test_access.sh</copy>
+[oracle@secdb b_ops_control]$ <copy>opsctl_30_test_access.sh</copy>
 
 (...)
 SQL> connect system/"MyDbPwd#1"@secdb/pdb1
@@ -252,7 +252,7 @@ ORA-01031: insufficient privileges
 For the rest of the workshop, we will however **disable Operations Control**. Please run the following script.
 
 ````
-$ <copy>opsctl_90_disable.sh</copy>
+[oracle@secdb b_ops_control]$ <copy>opsctl_90_disable.sh</copy>
 
 (...)
 SQL> begin
@@ -280,11 +280,11 @@ In the following demo, we will execute the following scenario:
 Create realm **HR_REALM** over the **HR** schema in **PDB1**. Run the following script from a terminal window to the secdb server
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv/b_realm</copy>
+[oracle@secdb ]$ <copy>cd /home/oracle/HOL/lab06_dbv/b_realm</copy>
 ````
 
 ````
-$ <copy>dbv10_dbvo_realm.sh</copy>
+[oracle@secdb b_realm]$ <copy>dbv10_dbvo_realm.sh</copy>
 
 (...)
 SQL> /*
@@ -318,11 +318,11 @@ PL/SQL procedure successfully completed.
 It is important to not create the role as **SYS**, but as the **Application Manager**. Otherwise the DBA will be able to later modify the role or grant it to himself. Run the following script from a terminal window to the secdb server:
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv/c_role</copy>
+[oracle@secdb ]$ <copy>cd /home/oracle/HOL/lab06_dbv/c_role</copy>
 ````
 
 ````
-$ <copy>dbv20_sys_grant.sh</copy>
+[oracle@secdb c_role]$ <copy>dbv20_sys_grant.sh</copy>
 
 (...)
 SQL> alter session set container=PDB1;
@@ -342,7 +342,7 @@ Grant succeeded.
 Run the following script.
 
 ````
-$ <copy>dbv30_dbvam_create_users.sh</copy>
+[oracle@secdb c_role]$ <copy>dbv30_dbvam_create_users.sh</copy>
 
 (...)
 SQL> --
@@ -367,7 +367,7 @@ Grant succeeded.
 Connect as the **Application Manager (HR)** to create the application role **APPROLE**. Run the following script from a terminal window to the secdb server. Note that the role is only granted to **APPUSER1** and not to **APPUSER2**.
 
 ````
-$ <copy>dbv40_hr_roleprivs.sh</copy>
+[oracle@secdb c_role]$ <copy>dbv40_hr_roleprivs.sh</copy>
 
 (...)
 SQL> create role APPROLE;
@@ -405,7 +405,7 @@ Protect role APPROLE by placing it in the realm to prevent privileged users such
 Please note that because we created a **mandatory** realm, we also need to make it realm **participant** in order to allow users granted this role to use their privileges.
 
 ````
-$ <copy>dbv50_dbvo_approle.sh</copy>
+[oracle@secdb c_role]$ <copy>dbv50_dbvo_approle.sh</copy>
 
 (...)
 SQL> /*
@@ -437,11 +437,11 @@ We can now test from the dbclient client that only **APPUSER1** (and not **APPUS
 First from APPUSER1 :
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv</copy>
+[oracle@dbclient ~]$ <copy>cd /home/oracle/HOL/lab06_dbv</copy>
 ````
 
 ````
-$ <copy>run_applic_appuser1.sh</copy>
+[oracle@dbclient lab06_dbv]$ <copy>run_applic_appuser1.sh</copy>
 
 (...)
 SQL> select * from hr.regions;
@@ -459,7 +459,7 @@ SQL> select * from hr.regions;
 Then from APPUSER2 :
 
 ````
-$ <copy>run_applic_appuser2.sh</copy>
+[oracle@dbclient lab06_dbv]$ <copy>run_applic_appuser2.sh</copy>
 
 (...)
 SQL> select * from hr.regions;
@@ -493,11 +493,11 @@ Here is the outline of the configuration :
 We will create three rules.
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv/d_secapprole</copy>
+[oracle@secdb ~]$ <copy>cd /home/oracle/HOL/lab06_dbv/d_secapprole</copy>
 ````
 
 ````
-$ <copy>sar10_dbvo_rules.sh</copy>
+[oracle@secdb d_secapprole]$ <copy>sar10_dbvo_rules.sh</copy>
 
 (...)
 SQL> /*
@@ -536,7 +536,7 @@ PL/SQL procedure successfully completed.
 ### Step 4b : Create a rule set ###
 
 ````
-$ <copy>sar20_dbvo_ruleset.sh</copy>
+[oracle@secdb d_secapprole]$ <copy>sar20_dbvo_ruleset.sh</copy>
 
 (...)
 SQL> /*
@@ -581,7 +581,7 @@ PL/SQL procedure successfully completed.
 Now create the Secure Application Role linked to the ruleset. Also protect it by putting it into the realm.
 
 ````
-$ <copy>sar30_dbvo_secapprole.sh</copy>
+[oracle@secdb d_secapprole]$ <copy>sar30_dbvo_secapprole.sh</copy>
 
 (...)
 SQL> /*
@@ -626,7 +626,7 @@ PL/SQL procedure successfully completed.
 Grant the privileges required to run the application to the Secure Application Role.
 
 ````
-$ <copy>sar40_hr_roleprivs.sh</copy>
+[oracle@secdb d_secapprole]$ <copy>sar40_hr_roleprivs.sh</copy>
 
 (...)
 SQL> grant select, insert, update, delete on HR.regions to SECAPPROLE;
@@ -651,11 +651,11 @@ Grant succeeded.
 We can now verify that it is not possible to connect as **APPUSER2** from **secdb**.
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv/d_secapprole</copy>
+[oracle@secdb ]$ <copy>cd /home/oracle/HOL/lab06_dbv/d_secapprole</copy>
 ````
 
 ````
-$ <copy>test_secapprole_appuser2.sh</copy>
+[oracle@secdb d_secapprole]$ <copy>test_secapprole_appuser2.sh</copy>
 
 (...)
 SQL> --
@@ -685,11 +685,11 @@ ORA-00942: table or view does not exist
 … but it works from **dbclient** :
 
 ````
-$ <copy>cd /home/oracle/HOL/lab06_dbv</copy>
+[oracle@dbclient ]$ <copy>cd /home/oracle/HOL/lab06_dbv</copy>
 ````
 
 ````
-$ <copy>test_secapprole_appuser2.sh</copy>
+[oracle@dbclient lab06_dbv]$ <copy>test_secapprole_appuser2.sh</copy>
 
 (...)
 SQL>

--- a/lab700/lab700_database_audit.md
+++ b/lab700/lab700_database_audit.md
@@ -246,7 +246,7 @@ Let us use it to view recent audit records.
 $ <copy>aud_95_view_audit.sh</copy>
 ````
 
-**This completes the Database Audit.** You can contienue with [Lab 8: Audit Vault](../lab800/lab800_audit_vault.md)
+**This completes the Database Audit.** You can continue with [Lab 8: Audit Vault](../lab800/lab800_audit_vault.md)
 
 ## Acknowledgements
 

--- a/lab900/lab900_data_masking.md
+++ b/lab900/lab900_data_masking.md
@@ -35,7 +35,7 @@ You can then connect to EM13cR3 at the following URL:
 
 **https://&lt EM CC PUBLIC IP &gt:7803/em**
 
-Allow a security exception as we are just using a self-signed certificate and connect as **sysman**, password **MyDbPwd#1**.
+Allow a security exception as we are just using a self-signed certificate and connect as **sysman**, password **MyDbPwd#1**
 
 ![Alt text](./images/img03.png " ")
 


### PR DESCRIPTION
Implemented lat series of DBSEC WS suggestions:

Suggestion: In Labs 5 and 6 the code blocks don't show on which server you are connected. 
Maybe it would be better to keep the same consistency as in previous labs and have the server name shown 
in code blocks to help users understand on which server they need to execute. 
-> DONE

Suggestion: In Lab6 Step4A, it would be good to have an explicit message saying to execute commands on secdb , 
it is not clear especially when finishing Step3F which was done on dbclient 
-> DONE

Suggestion: (optional lab) In Lab9 Step2 Connecting to OEM it would be better to remove the dot <.> 
right after the password at the end of the sentence just to make sure users don't think it's actually part
 of the password. The dot can be accidentally selected while copying the password.
-> DONE

Lab 6, Step 4 title has application mis-spelled as appliaction
-> DONE

Suggestion: in Lab 0 Step 2, we should include an example of how to create the SSH tunnel for non-PuTTY users,
 such as:  ssh -L 5902:LOCALHOST:5902 -i .ssh/dbseckey.txt oracle@dbipaddress
-> DONE

Doing Lab 8 (Audit Vault) and I get to step 3 (reporting). It specifies that you Click on the Reports tab and 
Activity Reports under Built-in Reports. However, there is no section called Built-in Reports. 
What you reference as Built-in Reports is really called Activity Reports.
-> I think we can leave it as it is ("Built-in Reports" shows on the left)

last line of Lab 7 there is a typo on the word continue.  It is contienue in the doc.
-> DONE

In Lab 8, Step 7, we are told to navigate to Reports > Built-in Reports > Activity Reports > Critical Alerts. 
Note that the Critical Alerts report is found under the subsection titled Alert Reports.
 Thus, you may want to append one more  Alert Reports to the end of the chain.
-> I think we can leave it as it is (clear enough in my opinion)

In Lab6: Database Vault , Step 4a.  The output of sar10_dbvo_rules.sh is incorrect should be
 rule_expr   => 'rtrim(SYS_CONTEXT(''USERENV'',''HOST''),''.localdomain'')=''dbclient'''
my doc has olclient
-> DONE
